### PR TITLE
Fix set param value when using log/param V2 (16k variables support)

### DIFF
--- a/include/crazyflie_cpp/Crazyflie.h
+++ b/include/crazyflie_cpp/Crazyflie.h
@@ -458,7 +458,8 @@ private:
   int m_curr_up;
   int m_curr_down;
 
-  bool m_log_param_use_V2;
+  bool m_log_use_V2;
+  bool m_param_use_V2;
 
   // logging
   Logger& m_logger;
@@ -477,7 +478,7 @@ public:
     , m_id(0)
   {
     m_id = m_cf->registerLogBlock([=](crtpLogDataResponse* r, uint8_t s) { this->handleData(r, s);});
-    if (m_cf->m_log_param_use_V2) {
+    if (m_cf->m_log_use_V2) {
       crtpLogCreateBlockV2Request request;
       request.id = m_id;
       int i = 0;
@@ -595,7 +596,7 @@ public:
     , m_id(0)
   {
     m_id = m_cf->registerLogBlock([=](crtpLogDataResponse* r, uint8_t s) { this->handleData(r, s);});
-    if (m_cf->m_log_param_use_V2) {
+    if (m_cf->m_log_use_V2) {
       crtpLogCreateBlockV2Request request;
       request.id = m_id;
       int i = 0;


### PR DESCRIPTION
When using Crazyswarm with the stock Bitcraze firmware, the Crazyflie is not taking off anymore. The problem has been traced to the param set value not being implemented for log/param V2 and so the parameter enabling high-level-controller was never enabled.

This PR implements set-value for param V2 and adds a flag in the Crazyflie object to keep track of what API is used.