### PR TITLE
Include address when raising timeout exception

### DIFF
--- a/include/crazyflie_cpp/Crazyflie.h
+++ b/include/crazyflie_cpp/Crazyflie.h
@@ -436,6 +436,15 @@ private:
     return reinterpret_cast<const R*>(m_batchRequests[index].ack.data);
   }
 
+  void throwTimeout()
+  {
+    std::stringstream message;
+    int lastbyte = 0xFF & m_address;
+    message << "timeout for Crazyflie " << std::hex << m_address
+      << " (last byte " << std::dec << lastbyte << ")";
+    throw std::runtime_error(message.str().c_str());
+  }
+
 private:
   struct logInfo {
     uint8_t len;

--- a/src/Crazyflie.cpp
+++ b/src/Crazyflie.cpp
@@ -434,7 +434,7 @@ void Crazyflie::writeFlash(
       //   auto end = std::chrono::system_clock::now();
       //   std::chrono::duration<double> elapsedSeconds = end-start;
       //   if (elapsedSeconds.count() > 1.0) {
-      //     throw std::runtime_error("timeout");
+      //     throwTimeout();
       //   }
       // }
       offset += requestedSize;
@@ -501,7 +501,7 @@ void Crazyflie::writeFlash(
           sendPacketOrTimeout(req, false);
           ++tries;
           if (tries > 5) {
-            throw std::runtime_error("timeout");
+            throwTimeout();
           }
         }
       }
@@ -1033,7 +1033,7 @@ bool Crazyflie::sendPacketInternal(
     auto end = std::chrono::system_clock::now();
     std::chrono::duration<double> elapsedSeconds = end-start;
     if (elapsedSeconds.count() > timeout) {
-      throw std::runtime_error("timeout");
+      throwTimeout();
     }
   }
 }
@@ -1302,7 +1302,7 @@ void Crazyflie::handleRequests(
           auto end = std::chrono::system_clock::now();
           std::chrono::duration<double> elapsedSeconds = end-start;
           if (elapsedSeconds.count() > timeout) {
-            throw std::runtime_error("timeout");
+            throwTimeout();
           }
           // std::cout << "send req " << requestIdx << std::endl;
         } while (!ack.ack);
@@ -1318,7 +1318,7 @@ void Crazyflie::handleRequests(
         auto end = std::chrono::system_clock::now();
         std::chrono::duration<double> elapsedSeconds = end-start;
         if (elapsedSeconds.count() > timeout) {
-          throw std::runtime_error("timeout");
+          throwTimeout();
         }
         // std::cout << "send ping " << m_numRequestsEnqueued << std::endl;
       }
@@ -1334,7 +1334,7 @@ void Crazyflie::handleRequests(
             auto end = std::chrono::system_clock::now();
             std::chrono::duration<double> elapsedSeconds = end-start;
             if (elapsedSeconds.count() > timeout) {
-              throw std::runtime_error("timeout");
+              throwTimeout();
             }
           }
         }
@@ -1354,7 +1354,7 @@ void Crazyflie::handleRequests(
           auto end = std::chrono::system_clock::now();
           std::chrono::duration<double> elapsedSeconds = end-start;
           if (elapsedSeconds.count() > timeout) {
-            throw std::runtime_error("timeout");
+            throwTimeout();
           }
         }
 


### PR DESCRIPTION
In Crazyswarm, this makes the "crazyswarm_server process has died..." error a bit easier to understand when attempting to connect to a Crazyflie that is not reachable on the radio. Helps with https://github.com/USC-ACTLab/crazyswarm/issues/380.