### PR TITLE
update connection layer

### DIFF
--- a/include/crazyflie_cpp/Crazyflie.h
+++ b/include/crazyflie_cpp/Crazyflie.h
@@ -35,6 +35,29 @@ public:
 
 extern Logger EmptyLogger;
 
+namespace crazyflie_cpp_detail {
+
+inline bitcraze::crazyflieLinkCpp::Connection::Statistics subtractStatistics(
+  const bitcraze::crazyflieLinkCpp::Connection::Statistics& current,
+  const bitcraze::crazyflieLinkCpp::Connection::Statistics& previous)
+{
+  auto diff = [](const std::atomic_size_t& currentValue, const std::atomic_size_t& previousValue) {
+    const size_t current = currentValue.load();
+    const size_t previous = previousValue.load();
+    return current >= previous ? current - previous : current;
+  };
+
+  bitcraze::crazyflieLinkCpp::Connection::Statistics delta;
+  delta.sent_count = diff(current.sent_count, previous.sent_count);
+  delta.sent_ping_count = diff(current.sent_ping_count, previous.sent_ping_count);
+  delta.receive_count = diff(current.receive_count, previous.receive_count);
+  delta.enqueued_count = diff(current.enqueued_count, previous.enqueued_count);
+  delta.ack_count = diff(current.ack_count, previous.ack_count);
+  return delta;
+}
+
+} // namespace crazyflie_cpp_detail
+
 class Crazyflie
 {
 public:
@@ -141,7 +164,10 @@ public:
 
   bitcraze::crazyflieLinkCpp::Connection::Statistics connectionStatsDelta()
   {
-    return m_connection.statisticsDelta();
+    auto current = m_connection.statistics();
+    auto delta = crazyflie_cpp_detail::subtractStatistics(current, m_connectionStatsSnapshot);
+    m_connectionStatsSnapshot = current;
+    return delta;
   }
 
   // returns the URI for this Crazyflie
@@ -477,6 +503,7 @@ private:
   Logger& m_logger;
 
   bitcraze::crazyflieLinkCpp::Connection m_connection;
+  bitcraze::crazyflieLinkCpp::Connection::Statistics m_connectionStatsSnapshot;
 
   // latency measurements
   std::chrono::time_point<std::chrono::steady_clock> m_clock_start;
@@ -764,7 +791,10 @@ public:
 
   bitcraze::crazyflieLinkCpp::Connection::Statistics connectionStatsDelta()
   {
-    return m_connection.statisticsDelta();
+    auto current = m_connection.statistics();
+    auto delta = crazyflie_cpp_detail::subtractStatistics(current, m_connectionStatsSnapshot);
+    m_connectionStatsSnapshot = current;
+    return delta;
   }
 
   void sendArmingRequest(bool arm);
@@ -837,4 +867,5 @@ public:
 
 private:
   bitcraze::crazyflieLinkCpp::Connection m_connection;
+  bitcraze::crazyflieLinkCpp::Connection::Statistics m_connectionStatsSnapshot;
 };

--- a/src/Crazyflie.cpp
+++ b/src/Crazyflie.cpp
@@ -37,6 +37,7 @@ Crazyflie::Crazyflie(
   , m_connection(link_uri)
   , m_clock_start(std::chrono::steady_clock::now())
   , m_latencyCounter(0)
+  , m_connectionStatsSnapshot(m_connection.statistics())
 {
 }
 
@@ -1219,6 +1220,7 @@ void Crazyflie::triggerLatencyMeasurement()
 CrazyflieBroadcaster::CrazyflieBroadcaster(
   const std::string& link_uri)
   : m_connection(link_uri)
+  , m_connectionStatsSnapshot(m_connection.statistics())
 {
 }
 


### PR DESCRIPTION
This fixes the build error:

```
--- stderr: crazyflie
In file included from /home/kimberly/ros_ws/src/crazyswarm2/crazyflie/deps/crazyflie_tools/crazyflie_cpp/src/Crazyflie.cpp:5:
/home/kimberly/ros_ws/src/crazyswarm2/crazyflie/deps/crazyflie_tools/crazyflie_cpp/include/crazyflie_cpp/Crazyflie.h: In member function ‘bitcraze::crazyflieLinkCpp::Connection::Statistics Crazyflie::connectionStatsDelta()’:
/home/kimberly/ros_ws/src/crazyswarm2/crazyflie/deps/crazyflie_tools/crazyflie_cpp/include/crazyflie_cpp/Crazyflie.h:144:25: error: ‘class bitcraze::crazyflieLinkCpp::Connection’ has no member named ‘statisticsDelta’; did you mean ‘statistics’?
  144 |     return m_connection.statisticsDelta();
      |                         ^~~~~~~~~~~~~~~
      |                         statistics
/home/kimberly/ros_ws/src/crazyswarm2/crazyflie/deps/crazyflie_tools/crazyflie_cpp/include/crazyflie_cpp/Crazyflie.h: In member function ‘bitcraze::crazyflieLinkCpp::Connection::Statistics CrazyflieBroadcaster::connectionStatsDelta()’:
/home/kimberly/ros_ws/src/crazyswarm2/crazyflie/deps/crazyflie_tools/crazyflie_cpp/include/crazyflie_cpp/Crazyflie.h:767:25: error: ‘class bitcraze::crazyflieLinkCpp::Connection’ has no member named ‘statisticsDelta’; did you mean ‘statistics’?
  767 |     return m_connection.statisticsDelta();
      |                         ^~~~~~~~~~~~~~~
      |                         statistics
gmake[2]: *** [deps/crazyflie_tools/crazyflie_cpp/CMakeFiles/crazyflie_cpp.dir/build.make:79: deps/crazyflie_tools/crazyflie_cpp/CMakeFiles/crazyflie_cpp.dir/src/Crazyflie.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:712: deps/crazyflie_tools/crazyflie_cpp/CMakeFiles/crazyflie_cpp.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
```